### PR TITLE
feat(build): add Jira Subdomain Scanner Utility

### DIFF
--- a/jira_findsub.py
+++ b/jira_findsub.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+import sys
+import requests
+import concurrent.futures
+import re
+
+# Timeout per request (detik)
+TIMEOUT = 5
+
+# Pola yang menunjukkan Jira
+JIRA_KEYWORDS = [
+    "Atlassian", "JIRA", "Jira Software", "jiraServiceDesk"
+]
+JIRA_HEADER_KEYS = [
+    "X-Atlassian-Token", "X-Seraph-LoginReason"
+]
+
+def is_jira(url):
+    try:
+        r = requests.get(url, timeout=TIMEOUT, allow_redirects=True, verify=False)
+        body = r.text[:20000]  # batasi body
+        # Cek keyword di body
+        if any(k.lower() in body.lower() for k in JIRA_KEYWORDS):
+            return True
+        # Cek header
+        if any(h in r.headers for h in JIRA_HEADER_KEYS):
+            return True
+        # Cek Server header
+        if "Server" in r.headers and "atlassian" in r.headers["Server"].lower():
+            return True
+    except requests.RequestException:
+        pass
+    return False
+
+def scan_subdomain(sub):
+    url_http = f"http://{sub}"
+    url_https = f"https://{sub}"
+    if is_jira(url_https):
+        return sub
+    elif is_jira(url_http):
+        return sub
+    return None
+
+def main():
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} subdomains.txt")
+        sys.exit(1)
+
+    input_file = sys.argv[1]
+    with open(input_file, "r") as f:
+        subs = [line.strip() for line in f if line.strip()]
+
+    found = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=20) as executor:
+        futures = {executor.submit(scan_subdomain, sub): sub for sub in subs}
+        for future in concurrent.futures.as_completed(futures):
+            sub = futures[future]
+            try:
+                result = future.result()
+                if result:
+                    print(f"[+] Jira detected: {result}")
+                    found.append(result)
+            except Exception:
+                pass
+
+    # Simpan hasil
+    with open("result.txt", "w") as out:
+        for sub in found:
+            out.write(sub + "\n")
+
+    print(f"[✓] Done! {len(found)} Jira domains saved to result.txt")
+
+if __name__ == "__main__":
+    requests.packages.urllib3.disable_warnings()  # disable warning SSL
+    main()


### PR DESCRIPTION
/claim #4

### Overview
This PR adds a new Python utility `jira_subdomain_scanner.py` that scans a list of subdomains and filters only those hosting Atlassian Jira instances. The tool is designed for reconnaissance purposes, helping identify Jira endpoints from large domain lists.

### Features
- Input from a text file (`subdomains.txt`) — one domain/subdomain per line.
- Checks both **HTTP** and **HTTPS**.
- Jira detection based on:
  - Body content keywords: `Atlassian`, `JIRA`, `Jira Software`, `jiraServiceDesk`
  - Response headers: `X-Atlassian-Token`, `X-Seraph-LoginReason`
  - `Server` header containing `Atlassian`
- Multi-threaded scanning for faster results.
- Skips SSL verification warnings for convenience.
- Saves only Jira domains to `result.txt`.

